### PR TITLE
[ADD] New XML File Action

### DIFF
--- a/src/main/kotlin/com/github/allepilli/odoodevelopmentplugin/actions/NewXmlFileAction.kt
+++ b/src/main/kotlin/com/github/allepilli/odoodevelopmentplugin/actions/NewXmlFileAction.kt
@@ -1,0 +1,14 @@
+package com.github.allepilli.odoodevelopmentplugin.actions
+
+import com.github.allepilli.odoodevelopmentplugin.bundles.StringsBundle
+import com.intellij.icons.AllIcons
+import com.intellij.ide.actions.CreateFileAction
+import java.util.function.Supplier
+
+class NewXmlFileAction: CreateFileAction(
+        StringsBundle.messagePointer("action.NewXmlFileAction.text"),
+        StringsBundle.messagePointer("action.NewXmlFileAction.description"),
+        Supplier { AllIcons.FileTypes.Xml }
+) {
+    override fun getDefaultExtension(): String = "xml"
+}

--- a/src/main/kotlin/com/github/allepilli/odoodevelopmentplugin/bundles/StringsBundle.kt
+++ b/src/main/kotlin/com/github/allepilli/odoodevelopmentplugin/bundles/StringsBundle.kt
@@ -1,0 +1,17 @@
+package com.github.allepilli.odoodevelopmentplugin.bundles
+
+import com.intellij.DynamicBundle
+import org.jetbrains.annotations.PropertyKey
+import java.util.function.Supplier
+
+object StringsBundle {
+    const val STRINGS_BUNDLE = "messages.StringsBundle"
+
+    private val bundle = DynamicBundle(StringsBundle::class.java, STRINGS_BUNDLE)
+
+    fun message(@PropertyKey(resourceBundle = STRINGS_BUNDLE) key: String, vararg params: Any): String =
+            bundle.getMessage(key, params)
+
+    fun messagePointer(@PropertyKey(resourceBundle = STRINGS_BUNDLE) key: String, vararg params: Any): Supplier<String> =
+            bundle.getLazyMessage(key, params)
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -29,4 +29,10 @@
     <extensions defaultExtensionNs="com.intellij">
 
     </extensions>
+
+    <actions>
+        <action class="com.github.allepilli.odoodevelopmentplugin.actions.NewXmlFileAction">
+            <add-to-group group-id="NewGroup" anchor="last"/>
+        </action>
+    </actions>
 </idea-plugin>

--- a/src/main/resources/messages/StringsBundle.properties
+++ b/src/main/resources/messages/StringsBundle.properties
@@ -1,0 +1,2 @@
+action.NewXmlFileAction.text=XML File
+action.NewXmlFileAction.description=Creates a new XML file


### PR DESCRIPTION
Pycharm does not provide an action to directly create a new XML file (like creating a new Python file) from a directory in the project toolwindow.