### PR TITLE
[ADD] New Manifest file action & template

### DIFF
--- a/src/main/kotlin/com/github/allepilli/odoodevelopmentplugin/Constants.kt
+++ b/src/main/kotlin/com/github/allepilli/odoodevelopmentplugin/Constants.kt
@@ -1,0 +1,6 @@
+package com.github.allepilli.odoodevelopmentplugin
+
+object Constants {
+    const val MANIFEST_FILE_NAME = "__manifest__"
+    const val MANIFEST_FILE_WITH_EXT = "$MANIFEST_FILE_NAME.py"
+}

--- a/src/main/kotlin/com/github/allepilli/odoodevelopmentplugin/OdooIcons.kt
+++ b/src/main/kotlin/com/github/allepilli/odoodevelopmentplugin/OdooIcons.kt
@@ -1,0 +1,8 @@
+package com.github.allepilli.odoodevelopmentplugin
+
+import com.intellij.openapi.util.IconLoader
+
+object OdooIcons {
+    @JvmField
+    val odoo = IconLoader.getIcon("/icons/odoo_icon.svg", javaClass)
+}

--- a/src/main/kotlin/com/github/allepilli/odoodevelopmentplugin/actions/NewOdooManifestFileAction.kt
+++ b/src/main/kotlin/com/github/allepilli/odoodevelopmentplugin/actions/NewOdooManifestFileAction.kt
@@ -1,0 +1,92 @@
+package com.github.allepilli.odoodevelopmentplugin.actions
+
+import com.github.allepilli.odoodevelopmentplugin.Constants
+import com.github.allepilli.odoodevelopmentplugin.dialogs.ManifestFormDialog
+import com.intellij.ide.actions.CreateFileAction
+import com.intellij.ide.fileTemplates.FileTemplate
+import com.intellij.ide.fileTemplates.FileTemplateManager
+import com.intellij.ide.fileTemplates.FileTemplateUtil
+import com.intellij.ide.fileTemplates.actions.CreateFromTemplateActionBase
+import com.intellij.ide.util.PropertiesComponent
+import com.intellij.openapi.actionSystem.*
+import com.intellij.openapi.application.WriteActionAware
+import com.intellij.openapi.fileEditor.FileEditorManager
+import com.intellij.psi.PsiDirectory
+import com.intellij.psi.PsiFile
+import com.intellij.psi.SmartPointerManager
+
+class NewOdooManifestFileAction: AnAction(), WriteActionAware {
+    companion object {
+        private const val PROP_NAME = "MODULE_NAME"
+        private const val PROP_VERSION = "MODULE_VERSION"
+        private const val PROP_CATEGORY = "MODULE_CATEGORY"
+        private const val PROP_DESCRIPTION = "MODULE_DESCRIPTION"
+        private const val PROP_LICENSE = "MODULE_LICENSE"
+    }
+
+    override fun actionPerformed(e: AnActionEvent) {
+        val dataContext = e.dataContext
+        val view = LangDataKeys.IDE_VIEW.getData(dataContext) ?: return
+        val project = CommonDataKeys.PROJECT.getData(dataContext) ?: return
+        val dir = view.orChooseDirectory ?: return
+
+        with(ManifestFormDialog(project)) {
+            if (showAndGet()) {
+                val template = FileTemplateManager.getInstance(project).getJ2eeTemplate("Manifest")
+                createManifestFile(template, dir, extraTemplateProperties = mapOf(
+                        PROP_NAME to (name.trim().takeUnless(String::isEmpty) ?: "Module Name"),
+                        PROP_VERSION to (version.trim().takeUnless(String::isEmpty) ?: "1.0"),
+                        PROP_CATEGORY to category.trim(),
+                        PROP_DESCRIPTION to description.trim(),
+                        PROP_LICENSE to license.trim()
+                ))
+            }
+        }
+    }
+
+    override fun update(e: AnActionEvent) {
+        val dataContext = e.dataContext
+        val psiDirectory = CommonDataKeys.PSI_ELEMENT.getData(dataContext) as? PsiDirectory ?: return
+
+        e.presentation.isEnabledAndVisible = psiDirectory.findFile(Constants.MANIFEST_FILE_WITH_EXT) == null
+    }
+
+    override fun getActionUpdateThread(): ActionUpdateThread = ActionUpdateThread.BGT
+
+    private fun createManifestFile(
+            template: FileTemplate,
+            directory: PsiDirectory,
+            openFile: Boolean = true,
+            extraTemplateProperties: Map<String, String> = emptyMap(),
+            liveTemplateDefaultValues: Map<String, String> = emptyMap(),
+            defaultTemplateProperty: String? = null
+    ): PsiFile? {
+        var dir: PsiDirectory
+        val name = with(CreateFileAction.MkDirs(Constants.MANIFEST_FILE_NAME, directory)) {
+            dir = this.directory
+            newName
+        }
+
+        val project = dir.project
+        val properties = FileTemplateManager.getInstance(project).defaultProperties.apply {
+            putAll(extraTemplateProperties)
+        }
+
+        val psiFile = FileTemplateUtil.createFromTemplate(template, name, properties, dir) as PsiFile
+        val pointer = SmartPointerManager.getInstance(project)
+                .createSmartPsiElementPointer(psiFile)
+
+        return psiFile.virtualFile?.let { virtualFile ->
+            if (openFile) {
+                if (template.isLiveTemplateEnabled) CreateFromTemplateActionBase.startLiveTemplate(psiFile, liveTemplateDefaultValues)
+                else FileEditorManager.getInstance(project).openFile(virtualFile, true)
+            }
+
+            defaultTemplateProperty?.let {
+                PropertiesComponent.getInstance(project).setValue(it, template.name)
+            }
+
+            pointer.element as PsiFile
+        }
+    }
+}

--- a/src/main/kotlin/com/github/allepilli/odoodevelopmentplugin/dialogs/ManifestFormDialog.kt
+++ b/src/main/kotlin/com/github/allepilli/odoodevelopmentplugin/dialogs/ManifestFormDialog.kt
@@ -1,0 +1,76 @@
+package com.github.allepilli.odoodevelopmentplugin.dialogs
+
+import com.github.allepilli.odoodevelopmentplugin.bundles.StringsBundle
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.observable.properties.ObservableProperty
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.ui.DialogWrapper
+import com.intellij.ui.dsl.builder.bindItem
+import com.intellij.ui.dsl.builder.bindText
+import com.intellij.ui.dsl.builder.panel
+import com.intellij.ui.dsl.builder.whenItemSelectedFromUi
+import com.intellij.ui.dsl.listCellRenderer.textListCellRenderer
+import javax.swing.JComponent
+import javax.swing.ListCellRenderer
+
+class ManifestFormDialog(project: Project, title: String = StringsBundle.message("dialog.ManifestFormDialog.title")): DialogWrapper(project) {
+    var name = ""
+    var version = ""
+    var category = ""
+    var description = ""
+
+    private var _license: License? = License.NONE
+    private var customLicense: String = ""
+    val license: String
+        get() = (_license ?: License.NONE)
+                .takeUnless { it == License.OTHER }
+                ?.value
+                ?: customLicense
+
+    init {
+        this.title = title
+        init()
+    }
+
+    enum class License(val value: String) {
+        LGPL3("LGPL-3"),
+        OEEL1("OEEL-1"),
+        OTHER("Other"),
+        NONE("");
+
+        companion object {
+            val renderer: ListCellRenderer<License?> = textListCellRenderer { it?.value }
+        }
+    }
+
+    override fun createCenterPanel(): JComponent = panel {
+        row(StringsBundle.message("dialog.ManifestFormDialog.label.module.name")) {
+            textField().bindText(this@ManifestFormDialog::name)
+        }
+        row(StringsBundle.message("dialog.ManifestFormDialog.label.version")) {
+            textField().bindText(this@ManifestFormDialog::version)
+                    .applyToComponent { text = "1.0" }
+        }
+        row(StringsBundle.message("dialog.ManifestFormDialog.label.category")) {
+            textField().bindText(this@ManifestFormDialog::category)
+        }
+        row(StringsBundle.message("dialog.ManifestFormDialog.label.description")) {
+            textArea().bindText(this@ManifestFormDialog::description)
+                    .applyToComponent { rows = 4 }
+        }
+        row(StringsBundle.message("dialog.ManifestFormDialog.label.license")) {
+            val licenseBox = comboBox(items = License.entries, renderer = License.renderer)
+                    .bindItem(this@ManifestFormDialog::_license)
+
+            textField().bindText(this@ManifestFormDialog::customLicense)
+                    .visibleIf(object : ObservableProperty<Boolean> {
+                        override fun get(): Boolean = _license == License.OTHER
+                        override fun afterChange(parentDisposable: Disposable?, listener: (Boolean) -> Unit) {
+                            licenseBox.whenItemSelectedFromUi {
+                                listener(it == License.OTHER)
+                            }
+                        }
+                    })
+        }
+    }
+}

--- a/src/main/kotlin/com/github/allepilli/odoodevelopmentplugin/templates/OdooFileTemplatesGroupFactory.kt
+++ b/src/main/kotlin/com/github/allepilli/odoodevelopmentplugin/templates/OdooFileTemplatesGroupFactory.kt
@@ -1,0 +1,21 @@
+package com.github.allepilli.odoodevelopmentplugin.templates
+
+import com.github.allepilli.odoodevelopmentplugin.OdooIcons
+import com.github.allepilli.odoodevelopmentplugin.bundles.StringsBundle
+import com.intellij.ide.fileTemplates.FileTemplateDescriptor
+import com.intellij.ide.fileTemplates.FileTemplateGroupDescriptor
+import com.intellij.ide.fileTemplates.FileTemplateGroupDescriptorFactory
+
+class OdooFileTemplatesGroupFactory: FileTemplateGroupDescriptorFactory {
+    override fun getFileTemplatesDescriptor(): FileTemplateGroupDescriptor = FileTemplateGroupDescriptor(
+            StringsBundle.message("template.OdooFileTemplatesGroupFactory.title"),
+            OdooIcons.odoo
+    ).apply {
+        addTemplate(
+                FileTemplateDescriptor(
+                        StringsBundle.message("template.OdooFileTemplatesGroupFactory.name.manifest"),
+                        OdooIcons.odoo
+                )
+        )
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -27,12 +27,22 @@
     <!-- Extension points defined by the plugin.
          Read more: https://plugins.jetbrains.com/docs/intellij/plugin-extension-points.html -->
     <extensions defaultExtensionNs="com.intellij">
-
+        <fileTemplateGroup
+                implementation="com.github.allepilli.odoodevelopmentplugin.templates.OdooFileTemplatesGroupFactory"
+                id="com.github.allepilli.odoodevelopmentplugin.templates.OdooFileTemplatesGroupFactory"/>
     </extensions>
 
-    <actions>
-        <action class="com.github.allepilli.odoodevelopmentplugin.actions.NewXmlFileAction">
+    <actions resource-bundle="messages.OdooActionsBundle">
+        <action class="com.github.allepilli.odoodevelopmentplugin.actions.NewOdooManifestFileAction"
+                id="NewOdooManifestFile"
+                text="Manifest File"
+                description="Creates a new __manifest__.py file"
+                icon="com.github.allepilli.odoodevelopmentplugin.OdooIcons.odoo">
             <add-to-group group-id="NewGroup" anchor="last"/>
+        </action>
+        <action class="com.github.allepilli.odoodevelopmentplugin.actions.NewXmlFileAction"
+                id="NewXmlFile">
+            <add-to-group group-id="NewGroup" anchor="before" relative-to-action="NewOdooManifestFile"/>
         </action>
     </actions>
 </idea-plugin>

--- a/src/main/resources/fileTemplates/j2ee/Manifest.py.ft
+++ b/src/main/resources/fileTemplates/j2ee/Manifest.py.ft
@@ -1,0 +1,18 @@
+{
+    'name': '${MODULE_NAME}',
+    'version': '${MODULE_VERSION}',
+    'category': '${MODULE_CATEGORY}',
+    'description': """
+    ${MODULE_DESCRIPTION}
+    """,
+    'depends': ['base'],
+    # data files always loaded at installation
+    'data': [
+
+    ],
+    # data files containing optionally loaded demonstration data
+    'demo': [
+
+    ],
+    'license': "${MODULE_LICENSE}"
+}

--- a/src/main/resources/fileTemplates/j2ee/Manifest.py.html
+++ b/src/main/resources/fileTemplates/j2ee/Manifest.py.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>An Odoo Module __manifest__.py File</title>
+</head>
+<body>
+<div>
+    <p>
+        Properties with default values:<br/>
+        - MODULE_NAME: "Module Name"<br/>
+        - MODULE_VERSION: "1.0"<br/>
+    </p>
+    <p>
+        See reference:
+        <a href="https://www.odoo.com/documentation/17.0/developer/reference/backend/module.html#reference-module-manifest">Odoo Reference</a>
+    </p>
+</div>
+</body>
+</html>

--- a/src/main/resources/icons/odoo_icon.svg
+++ b/src/main/resources/icons/odoo_icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16px" height="16px" viewBox="0 0 2048 2048">
+	<circle fill-opacity="1" r="768" cx="1024" cy="1024" fill="#ffffff" style="stroke: rgb(162, 70, 137); stroke-width: 384px; stroke-opacity: 1;"></circle>
+	<g transform="scale(1)"></g>
+</svg>

--- a/src/main/resources/messages/OdooActionsBundle.properties
+++ b/src/main/resources/messages/OdooActionsBundle.properties
@@ -1,0 +1,2 @@
+action.NewOdooManifestFileAction.text=Manifest file
+action.NewOdooManifestFileAction.description=Creates a new __manifest__.py file

--- a/src/main/resources/messages/StringsBundle.properties
+++ b/src/main/resources/messages/StringsBundle.properties
@@ -1,2 +1,12 @@
 action.NewXmlFileAction.text=XML File
 action.NewXmlFileAction.description=Creates a new XML file
+
+dialog.ManifestFormDialog.title=Create a Manifest File
+dialog.ManifestFormDialog.label.module.name=Module name:
+dialog.ManifestFormDialog.label.version=Version:
+dialog.ManifestFormDialog.label.category=Category:
+dialog.ManifestFormDialog.label.description=Description
+dialog.ManifestFormDialog.label.license=License
+
+template.OdooFileTemplatesGroupFactory.title=Odoo
+template.OdooFileTemplatesGroupFactory.name.manifest=Manifest


### PR DESCRIPTION
Template can be found and edited in Settings/Editor/File and Code Templates under the Other tab. Creates new __manifest__.py files for modules by using a custom dialog to fill in common data of the manifest file