### PR TITLE
[ADD] model reference from env instance

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,10 +14,10 @@ repositories {
 // Configure Gradle IntelliJ Plugin
 // Read more: https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html
 intellij {
-    version.set("2023.3.2")
+    version.set("2024.1")
     type.set("PC") // Target Pycharm Community Edition
 
-    plugins.set(listOf("PythonCore", "PsiViewer:233.2"))
+    plugins.set(listOf("PythonCore", "PsiViewer:241.14494.158-EAP-SNAPSHOT"))
 }
 
 tasks {
@@ -31,7 +31,7 @@ tasks {
     }
 
     patchPluginXml {
-        sinceBuild.set("233")
+        sinceBuild.set("241")
         untilBuild.set("241.*")
     }
 

--- a/src/main/kotlin/com/github/allepilli/odoodevelopmentplugin/references/python/model_in_env/ModelInEnvValuesContributor.kt
+++ b/src/main/kotlin/com/github/allepilli/odoodevelopmentplugin/references/python/model_in_env/ModelInEnvValuesContributor.kt
@@ -1,0 +1,19 @@
+package com.github.allepilli.odoodevelopmentplugin.references.python.model_in_env
+
+import com.intellij.patterns.PlatformPatterns
+import com.intellij.psi.PsiReferenceContributor
+import com.intellij.psi.PsiReferenceRegistrar
+import com.jetbrains.python.psi.PyReferenceExpression
+import com.jetbrains.python.psi.PyStringLiteralExpression
+import com.jetbrains.python.psi.PySubscriptionExpression
+
+private val pattern = PlatformPatterns.psiElement(PyStringLiteralExpression::class.java)
+        .withParent(
+                PlatformPatterns.psiElement(PySubscriptionExpression::class.java)
+                        .withChild(PlatformPatterns.psiElement(PyReferenceExpression::class.java))
+        )
+
+class ModelInEnvValuesContributor: PsiReferenceContributor() {
+    override fun registerReferenceProviders(registrar: PsiReferenceRegistrar) = registrar
+            .registerReferenceProvider(pattern, ModelInEnvValuesReferenceProvider())
+}

--- a/src/main/kotlin/com/github/allepilli/odoodevelopmentplugin/references/python/model_in_env/ModelInEnvValuesReferenceProvider.kt
+++ b/src/main/kotlin/com/github/allepilli/odoodevelopmentplugin/references/python/model_in_env/ModelInEnvValuesReferenceProvider.kt
@@ -1,0 +1,33 @@
+package com.github.allepilli.odoodevelopmentplugin.references.python.model_in_env
+
+import com.github.allepilli.odoodevelopmentplugin.references.ModelNameReference
+import com.intellij.openapi.util.TextRange
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiReference
+import com.intellij.psi.PsiReferenceProvider
+import com.intellij.psi.util.childrenOfType
+import com.intellij.util.ProcessingContext
+import com.jetbrains.python.psi.PyNamedParameter
+import com.jetbrains.python.psi.PyReferenceExpression
+import com.jetbrains.python.psi.PyStringLiteralUtil
+import com.jetbrains.python.psi.resolve.PyResolveContext
+import com.jetbrains.python.psi.types.TypeEvalContext
+
+class ModelInEnvValuesReferenceProvider: PsiReferenceProvider() {
+    override fun getReferencesByElement(psiElement: PsiElement, context: ProcessingContext): Array<PsiReference> {
+        val referenceExpression = psiElement.parent.childrenOfType<PyReferenceExpression>().singleOrNull() ?: return emptyArray()
+        val typeEvalContext = TypeEvalContext.codeAnalysis(psiElement.project, psiElement.containingFile)
+        val resolveElement = referenceExpression.followAssignmentsChain(PyResolveContext.implicitContext(typeEvalContext)).element
+
+        if (resolveElement is PyNamedParameter) {
+            val type = typeEvalContext.getType(resolveElement) ?: return emptyArray()
+
+            if (type.declarationElement?.qualifiedName == "odoo.api.Environment") {
+                val modelName = PyStringLiteralUtil.getStringValue(psiElement.text)
+                return arrayOf(ModelNameReference(psiElement, TextRange.allOf(modelName).shiftRight(1)))
+            }
+        }
+
+        return emptyArray()
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -40,6 +40,9 @@
         <psi.referenceContributor id="com.github.allepilli.odoodevelopmentplugin.references.python.model_inherit_values.ModelInheritValuesContributor"
                                   implementation="com.github.allepilli.odoodevelopmentplugin.references.python.model_inherit_values.ModelInheritValuesContributor"
                                   language="Python"/>
+        <psi.referenceContributor id="com.github.allepilli.odoodevelopmentplugin.references.python.model_in_env.ModelInEnvValuesContributor"
+                                  implementation="com.github.allepilli.odoodevelopmentplugin.references.python.model_in_env.ModelInEnvValuesContributor"
+                                  language="Python"/>
 
         <configurationType implementation="com.github.allepilli.odoodevelopmentplugin.execution.OdooConfigurationType"/>
 


### PR DESCRIPTION
It is now possible to resolve to models from instances of odoo.api.Environment. ex: self.env['account.move.line'] in a model