### PR TITLE
FIX: String out-of-bounds error for references in strings

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 }
 
 group = "com.github.AllePilli"
-version = "0.2.13"
+version = "0.2.14"
 
 repositories {
     mavenCentral()

--- a/src/main/kotlin/com/github/allepilli/odoodevelopmentplugin/references/FunctionReference.kt
+++ b/src/main/kotlin/com/github/allepilli/odoodevelopmentplugin/references/FunctionReference.kt
@@ -12,14 +12,13 @@ import com.intellij.psi.*
 import com.intellij.psi.util.parentOfType
 import com.jetbrains.python.psi.PyClass
 import com.jetbrains.python.psi.PyStringLiteralExpression
-import com.jetbrains.python.psi.PyStringLiteralUtil
 import com.jetbrains.python.psi.types.TypeEvalContext
 
 class FunctionReference(element: PyStringLiteralExpression, rangeInElement: TextRange?) : PsiReferenceBase<PyStringLiteralExpression>(element, rangeInElement), PsiPolyVariantReference {
     override fun resolve(): PsiElement? = multiResolve(false).singleOrNull()?.element
     override fun multiResolve(isCompleteCode: Boolean): Array<ResolveResult> {
         val pyClass = element.parentOfType<PyClass>() ?: return emptyArray()
-        val functionName = PyStringLiteralUtil.getStringValue(element.text)
+        val functionName = value
 
         val modelName = pyClass.getModelName()
         val moduleName = pyClass.containingModule?.name

--- a/src/main/kotlin/com/github/allepilli/odoodevelopmentplugin/references/ModelNameReference.kt
+++ b/src/main/kotlin/com/github/allepilli/odoodevelopmentplugin/references/ModelNameReference.kt
@@ -11,17 +11,13 @@ import com.intellij.psi.xml.XmlAttributeValue
 import com.jetbrains.python.PythonLanguage
 
 class ModelNameReference(psiElement: PsiElement, rangeInElement: TextRange, val canReferenceContainingClass: Boolean = true)
-    : PsiReferenceBase<PsiElement>(psiElement, rangeInElement), PsiPolyVariantReference {
+    : PsiPolyVariantReferenceBase<PsiElement>(psiElement, rangeInElement), PsiPolyVariantReference {
         constructor(xmlAttributeValue: XmlAttributeValue)
                 : this(xmlAttributeValue, TextRange.allOf(xmlAttributeValue.value).shiftRight(1))
 
-    override fun resolve(): PsiElement? = multiResolve(false).singleOrNull()?.element
     override fun multiResolve(isCompleteCode: Boolean): Array<ResolveResult> = buildArray {
         val module = element.containingFile.virtualFile.getContainingModule(element.project)
-        val name = buildString {
-            append(element.text, rangeInElement.startOffset, rangeInElement.endOffset)
-        }
-
+        val name = value
         val models = OdooModelNameIndexUtil.findModelsByName(element.project, name, moduleRoot = module)
 
         if (!canReferenceContainingClass && element.language == PythonLanguage.getInstance()) {

--- a/src/main/kotlin/com/github/allepilli/odoodevelopmentplugin/references/ModuleReference.kt
+++ b/src/main/kotlin/com/github/allepilli/odoodevelopmentplugin/references/ModuleReference.kt
@@ -22,7 +22,7 @@ import java.io.File
 
 class ModuleReference(psiElement: PsiElement, rangeInElement: TextRange): PsiReferenceBase<PsiElement>(psiElement, rangeInElement) {
     override fun resolve(): PsiElement? {
-        val moduleName = PyStringLiteralUtil.getStringValue(element.text)
+        val moduleName = value
         val virtualFileManager = VirtualFileManager.getInstance()
         var module: VirtualFile? = null
 
@@ -43,7 +43,7 @@ class ModuleReference(psiElement: PsiElement, rangeInElement: TextRange): PsiRef
         val virtualFileManager = VirtualFileManager.getInstance()
 
         // Can't use PsiElement.containingModule because the element in this function is some kind of temporary element with minimal context.
-        // to get the actual containing module we need to go through the document
+        // to get the actual containing module, we need to go through the document
         val moduleName = if (ApplicationManager.getApplication().isUnitTestMode) {
             FileDocumentManager.getInstance().getFile(element.containingFile.fileDocument)
                     ?.originalFile()

--- a/src/main/kotlin/com/github/allepilli/odoodevelopmentplugin/references/python/PyStringLiteralReferenceProvider.kt
+++ b/src/main/kotlin/com/github/allepilli/odoodevelopmentplugin/references/python/PyStringLiteralReferenceProvider.kt
@@ -1,0 +1,20 @@
+package com.github.allepilli.odoodevelopmentplugin.references.python
+
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiReference
+import com.intellij.psi.PsiReferenceProvider
+import com.intellij.util.ProcessingContext
+import com.jetbrains.python.psi.PyStringLiteralExpression
+import com.jetbrains.python.psi.PyStringLiteralUtil
+
+/**
+ * [PsiReferenceProvider] specifically for references inside [PyStringLiteralExpression]s.
+ * Adds some error prevention for strings with unbalanced quotes.
+ */
+abstract class PyStringLiteralReferenceProvider: PsiReferenceProvider() {
+    final override fun getReferencesByElement(element: PsiElement, context: ProcessingContext): Array<PsiReference> =
+            if (element !is PyStringLiteralExpression || !PyStringLiteralUtil.isQuoted(element.text)) emptyArray()
+            else getReferences(element, context).toTypedArray()
+
+    abstract fun getReferences(element: PyStringLiteralExpression, context: ProcessingContext): List<PsiReference>
+}

--- a/src/main/kotlin/com/github/allepilli/odoodevelopmentplugin/references/python/field_keywordarg_function_reference/FieldKeywordArgFunctionReferenceProvider.kt
+++ b/src/main/kotlin/com/github/allepilli/odoodevelopmentplugin/references/python/field_keywordarg_function_reference/FieldKeywordArgFunctionReferenceProvider.kt
@@ -1,11 +1,10 @@
 package com.github.allepilli.odoodevelopmentplugin.references.python.field_keywordarg_function_reference
 
 import com.github.allepilli.odoodevelopmentplugin.references.FunctionReference
+import com.github.allepilli.odoodevelopmentplugin.references.python.PyStringLiteralReferenceProvider
 import com.intellij.openapi.util.Key
-import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiReference
-import com.intellij.psi.PsiReferenceProvider
 import com.intellij.psi.util.parentOfType
 import com.intellij.psi.util.siblings
 import com.intellij.util.ProcessingContext
@@ -48,20 +47,19 @@ private val fieldTypes = setOf(
 
 private val IS_FIELD_ARG_LIST_KEY = Key.create<Boolean>("odoo_development_plugin_is_field_arg_list_key")
 
-class FieldKeywordArgFunctionReferenceProvider: PsiReferenceProvider() {
-    override fun getReferencesByElement(psiElement: PsiElement, context: ProcessingContext): Array<PsiReference> {
-        if (!isKeywordArgInFieldDefinition(psiElement)) return emptyArray()
+class FieldKeywordArgFunctionReferenceProvider: PyStringLiteralReferenceProvider() {
+    override fun getReferences(element: PyStringLiteralExpression, context: ProcessingContext): List<PsiReference> {
+        if (!isKeywordArgInFieldDefinition(element)) return emptyList()
 
-        val keywordIdentifier = psiElement.siblings(forward = false, withSelf = false)
+        val keywordIdentifier = element.siblings(forward = false, withSelf = false)
                 .drop(1) // drop the '=' element
                 .firstOrNull()
                 ?.takeIf { it.elementType == PyTokenTypes.IDENTIFIER }
-                ?: return emptyArray()
+                ?: return emptyList()
 
-        if (keywordIdentifier.text !in functionReferenceKeywords) return emptyArray()
+        if (keywordIdentifier.text !in functionReferenceKeywords) return emptyList()
 
-        val functionName = PyStringLiteralUtil.getStringValue(psiElement.text)
-        return arrayOf(FunctionReference(psiElement as PyStringLiteralExpression, TextRange.allOf(functionName).shiftRight(1)))
+        return listOf(FunctionReference(element, PyStringLiteralUtil.getContentRange(element.text)))
     }
 
     private fun isKeywordArgInFieldDefinition(psiElement: PsiElement): Boolean {

--- a/src/main/kotlin/com/github/allepilli/odoodevelopmentplugin/references/python/fields_in_odoo_api_decorator_args/FieldsInOdooApiDecoratorArgsProvider.kt
+++ b/src/main/kotlin/com/github/allepilli/odoodevelopmentplugin/references/python/fields_in_odoo_api_decorator_args/FieldsInOdooApiDecoratorArgsProvider.kt
@@ -1,15 +1,15 @@
 package com.github.allepilli.odoodevelopmentplugin.references.python.fields_in_odoo_api_decorator_args
 
 import com.github.allepilli.odoodevelopmentplugin.references.SimpleFieldNameReference
+import com.github.allepilli.odoodevelopmentplugin.references.python.PyStringLiteralReferenceProvider
 import com.intellij.openapi.util.TextRange
-import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiReference
-import com.intellij.psi.PsiReferenceProvider
 import com.intellij.util.ProcessingContext
+import com.jetbrains.python.psi.PyStringLiteralExpression
 import com.jetbrains.python.psi.PyStringLiteralUtil
 
-class FieldsInOdooApiDecoratorArgsProvider: PsiReferenceProvider() {
-    override fun getReferencesByElement(element: PsiElement, context: ProcessingContext): Array<PsiReference> {
+class FieldsInOdooApiDecoratorArgsProvider: PyStringLiteralReferenceProvider() {
+    override fun getReferences(element: PyStringLiteralExpression, context: ProcessingContext): List<PsiReference> {
         val fieldName = PyStringLiteralUtil.getStringValue(element.text)
 
         val dotIndices = fieldName.mapIndexed { idx, c -> if (c == '.') idx else null }
@@ -20,24 +20,23 @@ class FieldsInOdooApiDecoratorArgsProvider: PsiReferenceProvider() {
                 }
 
         var prevDotIdx = -1
-        val fieldReferences: MutableList<SimpleFieldNameReference> = mutableListOf()
 
-        for (dotIdx in dotIndices) {
-            val textRange = TextRange.create(prevDotIdx + 1, dotIdx).shiftRight(1)
-            val modelName = fieldReferences.lastOrNull()
-                    ?.apply { multiResolve(false) } // Do the calculations
-                    ?.coModelName
+        return buildList<SimpleFieldNameReference> {
+            for (dotIdx in dotIndices) {
+                val textRange = TextRange.create(prevDotIdx + 1, dotIdx).shiftRight(1)
+                val modelName = lastOrNull()
+                        ?.apply { multiResolve(false) } // Do the calculations
+                        ?.coModelName
 
-            if (modelName == null && prevDotIdx > 0)
-                // prevDotIdx > 0 means we are not checking the first field in the chain
-                // we encountered field access on a non-relational field
-                // which should not be possible, but people make mistakes ¯\_(ツ)_/¯
-                break
+                if (modelName == null && prevDotIdx > 0)
+                    // prevDotIdx > 0 means we are not checking the first field in the chain
+                    // we encountered field access on a non-relational field
+                    // which should not be possible, but people make mistakes ¯\_(ツ)_/¯
+                    break
 
-            fieldReferences.add(SimpleFieldNameReference(element, textRange, modelName))
-            prevDotIdx = dotIdx
+                add(SimpleFieldNameReference(element, textRange, modelName))
+                prevDotIdx = dotIdx
+            }
         }
-
-        return fieldReferences.toTypedArray()
     }
 }

--- a/src/main/kotlin/com/github/allepilli/odoodevelopmentplugin/references/python/manifest_module_dependency/ManifestModuleDependencyReferenceProvider.kt
+++ b/src/main/kotlin/com/github/allepilli/odoodevelopmentplugin/references/python/manifest_module_dependency/ManifestModuleDependencyReferenceProvider.kt
@@ -1,14 +1,13 @@
 package com.github.allepilli.odoodevelopmentplugin.references.python.manifest_module_dependency
 
 import com.github.allepilli.odoodevelopmentplugin.references.ModuleReference
-import com.intellij.openapi.util.TextRange
-import com.intellij.psi.PsiElement
+import com.github.allepilli.odoodevelopmentplugin.references.python.PyStringLiteralReferenceProvider
 import com.intellij.psi.PsiReference
-import com.intellij.psi.PsiReferenceProvider
 import com.intellij.util.ProcessingContext
+import com.jetbrains.python.psi.PyStringLiteralExpression
 import com.jetbrains.python.psi.PyStringLiteralUtil
 
-class ManifestModuleDependencyReferenceProvider: PsiReferenceProvider() {
-    override fun getReferencesByElement(element: PsiElement, context: ProcessingContext): Array<PsiReference> =
-            arrayOf(ModuleReference(element, TextRange.allOf(PyStringLiteralUtil.getStringValue(element.text)).shiftRight(1)))
+class ManifestModuleDependencyReferenceProvider: PyStringLiteralReferenceProvider() {
+    override fun getReferences(element: PyStringLiteralExpression, context: ProcessingContext): List<PsiReference> =
+            listOf(ModuleReference(element, PyStringLiteralUtil.getContentRange(element.text)))
 }

--- a/src/main/kotlin/com/github/allepilli/odoodevelopmentplugin/references/python/model_in_comodel_args/ModelInComodelArgsReferenceProvider.kt
+++ b/src/main/kotlin/com/github/allepilli/odoodevelopmentplugin/references/python/model_in_comodel_args/ModelInComodelArgsReferenceProvider.kt
@@ -1,17 +1,15 @@
 package com.github.allepilli.odoodevelopmentplugin.references.python.model_in_comodel_args
 
 import com.github.allepilli.odoodevelopmentplugin.references.ModelNameReference
-import com.intellij.openapi.util.TextRange
-import com.intellij.psi.PsiElement
+import com.github.allepilli.odoodevelopmentplugin.references.python.PyStringLiteralReferenceProvider
 import com.intellij.psi.PsiReference
-import com.intellij.psi.PsiReferenceProvider
 import com.intellij.psi.util.childrenOfType
 import com.intellij.psi.util.parentOfType
 import com.intellij.util.ProcessingContext
 import com.jetbrains.python.FunctionParameter
 import com.jetbrains.python.psi.*
 
-class ModelInComodelArgsReferenceProvider: PsiReferenceProvider() {
+class ModelInComodelArgsReferenceProvider: PyStringLiteralReferenceProvider() {
     private val classes = setOf("Many2one", "One2many", "Many2many")
 
     private fun getCoModelParameter(isKeywordArgument: Boolean) = object : FunctionParameter {
@@ -19,23 +17,22 @@ class ModelInComodelArgsReferenceProvider: PsiReferenceProvider() {
         override fun getName(): String? = if (isKeywordArgument) "comodel_name" else null
     }
 
-    override fun getReferencesByElement(psiElement: PsiElement, context: ProcessingContext): Array<out PsiReference?> {
-        val argumentList = psiElement.parentOfType<PyArgumentList>() ?: return emptyArray()
-        val parameterExpression = argumentList.getValueExpressionForParam(getCoModelParameter(psiElement.parent is PyKeywordArgument))
-                ?: return emptyArray()
+    override fun getReferences(element: PyStringLiteralExpression, context: ProcessingContext): List<PsiReference> {
+        val argumentList = element.parentOfType<PyArgumentList>() ?: return emptyList()
+        val parameterExpression = argumentList.getValueExpressionForParam(getCoModelParameter(element.parent is PyKeywordArgument))
+                ?: return emptyList()
 
-        if (parameterExpression != psiElement) return emptyArray()
+        if (parameterExpression != element) return emptyList()
 
-        val callExpression = argumentList.parent as? PyCallExpression ?: return emptyArray()
+        val callExpression = argumentList.parent as? PyCallExpression ?: return emptyList()
         val referenceExpression = callExpression.childrenOfType<PyReferenceExpression>()
                 .firstOrNull()
-                ?: return emptyArray()
+                ?: return emptyList()
 
         if (referenceExpression.name in classes) {
-            val modelName = PyStringLiteralUtil.getStringValue(psiElement.text)
-            return arrayOf(ModelNameReference(psiElement, TextRange.allOf(modelName).shiftRight(1)))
+            return listOf(ModelNameReference(element, PyStringLiteralUtil.getContentRange(element.text)))
         }
 
-        return emptyArray()
+        return emptyList()
     }
 }

--- a/src/main/kotlin/com/github/allepilli/odoodevelopmentplugin/references/python/model_in_env/ModelInEnvValuesReferenceProvider.kt
+++ b/src/main/kotlin/com/github/allepilli/odoodevelopmentplugin/references/python/model_in_env/ModelInEnvValuesReferenceProvider.kt
@@ -1,23 +1,21 @@
 package com.github.allepilli.odoodevelopmentplugin.references.python.model_in_env
 
 import com.github.allepilli.odoodevelopmentplugin.references.ModelNameReference
-import com.intellij.openapi.util.TextRange
-import com.intellij.psi.PsiElement
+import com.github.allepilli.odoodevelopmentplugin.references.python.PyStringLiteralReferenceProvider
 import com.intellij.psi.PsiReference
-import com.intellij.psi.PsiReferenceProvider
 import com.intellij.psi.util.childrenOfType
 import com.intellij.util.ProcessingContext
 import com.jetbrains.python.psi.PyReferenceExpression
+import com.jetbrains.python.psi.PyStringLiteralExpression
 import com.jetbrains.python.psi.PyStringLiteralUtil
 
-class ModelInEnvValuesReferenceProvider: PsiReferenceProvider() {
-    override fun getReferencesByElement(psiElement: PsiElement, context: ProcessingContext): Array<PsiReference> {
-        val caller = psiElement.parent.childrenOfType<PyReferenceExpression>().singleOrNull() ?: return emptyArray()
-        if (caller.text == "self.env") {
-            val modelName = PyStringLiteralUtil.getStringValue(psiElement.text)
-            return arrayOf(ModelNameReference(psiElement, TextRange.allOf(modelName).shiftRight(1)))
-        }
-
-        return emptyArray()
-    }
+class ModelInEnvValuesReferenceProvider: PyStringLiteralReferenceProvider() {
+    override fun getReferences(element: PyStringLiteralExpression, context: ProcessingContext): List<PsiReference> =
+            element.parent
+                    .childrenOfType<PyReferenceExpression>()
+                    .singleOrNull()
+                    ?.text
+                    ?.takeIf { it == "self.env" }
+                    ?.let { _ -> listOf(ModelNameReference(element, PyStringLiteralUtil.getContentRange(element.text))) }
+                    ?: emptyList()
 }

--- a/src/main/kotlin/com/github/allepilli/odoodevelopmentplugin/references/python/model_inherit_values/ModelInheritValuesReferenceProvider.kt
+++ b/src/main/kotlin/com/github/allepilli/odoodevelopmentplugin/references/python/model_inherit_values/ModelInheritValuesReferenceProvider.kt
@@ -1,16 +1,13 @@
 package com.github.allepilli.odoodevelopmentplugin.references.python.model_inherit_values
 
 import com.github.allepilli.odoodevelopmentplugin.references.ModelNameReference
-import com.intellij.openapi.util.TextRange
-import com.intellij.psi.PsiElement
+import com.github.allepilli.odoodevelopmentplugin.references.python.PyStringLiteralReferenceProvider
 import com.intellij.psi.PsiReference
-import com.intellij.psi.PsiReferenceProvider
 import com.intellij.util.ProcessingContext
 import com.jetbrains.python.psi.PyStringLiteralExpression
+import com.jetbrains.python.psi.PyStringLiteralUtil
 
-class ModelInheritValuesReferenceProvider: PsiReferenceProvider() {
-    override fun getReferencesByElement(psiElement: PsiElement, context: ProcessingContext): Array<PsiReference> =
-            if (psiElement is PyStringLiteralExpression) arrayOf(
-                    ModelNameReference(psiElement, TextRange.allOf(psiElement.stringValue).shiftRight(1), canReferenceContainingClass = false)
-            ) else emptyArray()
+class ModelInheritValuesReferenceProvider : PyStringLiteralReferenceProvider() {
+    override fun getReferences(element: PyStringLiteralExpression, context: ProcessingContext): List<PsiReference> =
+            listOf(ModelNameReference(element, PyStringLiteralUtil.getContentRange(element.text), canReferenceContainingClass = false))
 }


### PR DESCRIPTION
The problem lies in the fact that when deleting a string, the closing quote(s) get deleted first, and in every reference we used to shift the text range to the right by one place. The combination of the two resulted in an out-of-bounds error.

The fix simply checks if a PyStringLiteralExpression has balanced quotes before doing calculations on it

task: bb94902a-c7d2-494f-bb8b-f52ccc8318d5